### PR TITLE
MacOS Fix.

### DIFF
--- a/Goldtree.py
+++ b/Goldtree.py
@@ -150,7 +150,7 @@ def main():
                             drive_labels[letter] = label_buf.value
                     bitmask >>= 1
             else:
-                Goldleaf.drives["ROOT"] = "/"
+                drives["ROOT"] = "/"
             write_u32(len(drives))
             for d in drives:
                 try:

--- a/Goldtree.py
+++ b/Goldtree.py
@@ -127,7 +127,7 @@ def main():
                 return 0
         if c.has_id(CommandId.ListSystemDrives):
             drive_labels = {}
-            if "win" not in sys.platform:
+            if "linux" in sys.platform or "darwin" in sys.platform or "freebsd" in sys.platform or "openbsd" in sys.platform:
                 drives["ROOT"] = "/"
             else:
                 import string

--- a/Goldtree.py
+++ b/Goldtree.py
@@ -127,9 +127,7 @@ def main():
                 return 0
         if c.has_id(CommandId.ListSystemDrives):
             drive_labels = {}
-            if "linux" in sys.platform or "darwin" in sys.platform or "freebsd" in sys.platform or "openbsd" in sys.platform:
-                drives["ROOT"] = "/"
-            else:
+            if "win" in value[:3].lower():
                 import string
                 import ctypes
                 kernel32 = ctypes.windll.kernel32
@@ -151,6 +149,8 @@ def main():
                         if label_buf.value:
                             drive_labels[letter] = label_buf.value
                     bitmask >>= 1
+            else:
+                Goldleaf.drives["ROOT"] = "/"
             write_u32(len(drives))
             for d in drives:
                 try:


### PR DESCRIPTION
The previous code will erroneously think OSX users are running windows and crash. Because their sys.platform spits out "darwin" which does in fact contain "win". This is a more thorough check to ensure that an user is in fact, running windows.

Here's the docs detailing sys.platform:
https://docs.python.org/2/library/sys.html